### PR TITLE
StringSource uses default encoding when calling getBytes() on XML-String #6

### DIFF
--- a/xml-matchers/src/main/java/org/xmlmatchers/transform/StringSource.java
+++ b/xml-matchers/src/main/java/org/xmlmatchers/transform/StringSource.java
@@ -16,6 +16,8 @@
 package org.xmlmatchers.transform;
 
 import java.io.ByteArrayInputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.Charset;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -23,6 +25,7 @@ import javax.xml.transform.Source;
 import javax.xml.transform.dom.DOMSource;
 
 import org.w3c.dom.Document;
+import org.xml.sax.InputSource;
 
 /**
  * A convenience class for creating {@link Source} objects from a String. 
@@ -34,7 +37,7 @@ public class StringSource extends DOMSource {
 	
 	private final String xml;
 	
-	private StringSource(String xml) throws RuntimeException {
+	private StringSource(String xml, Charset charset) throws RuntimeException {
 		this.xml = xml;
 		try {
 			DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory
@@ -42,8 +45,10 @@ public class StringSource extends DOMSource {
 			documentBuilderFactory.setNamespaceAware(true);
 			DocumentBuilder documentBuilder = documentBuilderFactory
 					.newDocumentBuilder();
-			Document dom = documentBuilder.parse(new ByteArrayInputStream(xml
-					.getBytes()));
+			InputStreamReader reader = new InputStreamReader(new ByteArrayInputStream(xml.getBytes(charset)), charset);
+            InputSource inputSource = new InputSource(reader);
+            inputSource.setEncoding(charset.name());
+            Document dom = documentBuilder.parse(inputSource);
 			setNode(dom);
 		} catch (Exception e) {
 			throw new IllegalArgumentException(e);
@@ -51,7 +56,11 @@ public class StringSource extends DOMSource {
 	}
 
 	public static DOMSource toSource(String xml) throws RuntimeException {
-		return new StringSource(xml);
+		return new StringSource(xml, Charset.defaultCharset());
+	}
+
+	public static DOMSource toSource(String xml, String charsetName) throws RuntimeException {
+		return new StringSource(xml, Charset.forName(charsetName));
 	}
 
 	@Override

--- a/xml-matchers/src/main/java/org/xmlmatchers/transform/XmlConverters.java
+++ b/xml-matchers/src/main/java/org/xmlmatchers/transform/XmlConverters.java
@@ -51,6 +51,10 @@ public class XmlConverters {
 		return StringSource.toSource(xml);
 	}
 
+	public static Source the(String xml, String charsetName) {
+		return StringSource.toSource(xml, charsetName);
+	}
+
 	public static Source the(final Node node) {
 		return new DOMSource(node) {
 			@Override

--- a/xml-matchers/src/test/java/org/xmlmatchers/transform/XmlConvertersTest.java
+++ b/xml-matchers/src/test/java/org/xmlmatchers/transform/XmlConvertersTest.java
@@ -18,6 +18,7 @@ package org.xmlmatchers.transform;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.xmlmatchers.transform.XmlConverters.the;
+import static org.xmlmatchers.xpath.XpathReturnType.returningAnXmlNode;
 import static org.xmlmatchers.XmlMatchers.*;
 
 import java.io.ByteArrayInputStream;
@@ -76,4 +77,11 @@ public class XmlConvertersTest {
 
 		assertNotNull(the(result));
 	}
+	
+	@Test
+    public void thatXmlCanBeCreatedFromNonUTF8() throws Exception {
+        String xml = new String("<?xml version=\"1.0\"?><this><is><xml>t\u00E9st</xml></is></this>".getBytes("ISO-8859-1"), "ISO-8859-1");
+        assertThat(the(xml, "ISO-8859-1"), hasXPath("/this/is/xml", returningAnXmlNode(), isEquivalentTo(the("<xml>tést</xml>"))));
+    }
+    
 }


### PR DESCRIPTION
Created an alternative constructor that allows passing a Charset when creating the ByteArrayInputStream for the DocumentBuilder.

'https://github.com/davidehringer/xml-matchers/issues/6'
